### PR TITLE
CMakeLists.txt: support modern LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 ################################################################################
 
 find_package(Clang REQUIRED)
+find_package(LLVM REQUIRED)
+
 message("LLVM STATUS:
   Definitions ${LLVM_DEFINITIONS}
   Includes    ${LLVM_INCLUDE_DIRS}
@@ -22,9 +24,19 @@ message("LLVM STATUS:
   Libraries   ${LLVM_LIBRARY_DIRS}"
 )
 
+list(APPEND LINK_LIBRARIES LLVM ${CLANG_LIBRARIES})
+
+# Determine if clang-cpp target is available
+if(TARGET clang-cpp)
+  list(APPEND LINK_LIBRARIES clang-cpp)
+  message("Linking with clang-cpp target")
+else()
+  # For older versions, manually add necessary Clang libraries
+  list(APPEND LINK_LIBRARIES clangBasic clangAST clangFrontend clangSerialization clangTooling)
+  message("Linking with individual Clang libraries")
+endif()
+# Add LLVM and Clang include directories
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
-link_directories(${LLVM_LIBRARY_DIRS})
-add_definitions(${LLVM_DEFINITIONS})
 
 ################################################################################
 # mockoto build rules
@@ -44,15 +56,9 @@ add_executable(mockoto Mockoto.cpp)
 add_dependencies(mockoto binders)
 target_include_directories(mockoto PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-# link to clang libraries
-target_link_libraries(mockoto
-  PRIVATE
-  clangAST
-  clangBasic
-  clangFrontend
-  clangSerialization
-  clangTooling
-)
+# link to clang and LLVM libraries
+
+target_link_libraries(mockoto PRIVATE ${LINK_LIBRARIES})
 
 ################################################################################
 # installation


### PR DESCRIPTION
Modern LLVM setups does not provide separate libraries to access LLVM and CLANG internals.
Instead, most of required logic for AST traversal and for a frontend is now incorporated into libclang-cpp.so.